### PR TITLE
fix: exclude GPU files from coverage

### DIFF
--- a/docs/user-guide/gpu.rst
+++ b/docs/user-guide/gpu.rst
@@ -27,7 +27,7 @@ buffers used internally by Zarr.
 Note that the output type is a ``cupy.ndarray`` rather than a NumPy array.
 
 For supported codecs, data will be decoded using the GPU via the `nvcomp`_
-library. See :ref:`user-guide-config` for more. Isseus and feature requests
+library. See :ref:`user-guide-config` for more. Issues and feature requests
 for NVIDIA nvCOMP can be reported in the `nvcomp issue tracker`_.
 
 .. _nvcomp: https://docs.nvidia.com/cuda/nvcomp/samples/python_samples.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,8 @@ exclude_also = [
 omit = [
     "bench/compress_normal.py",
     "src/zarr/testing/conftest.py",  # only for downstream projects
+    "src/zarr/codecs/gpu.py",  # requires GPU hardware not available in CI
+    "src/zarr/core/buffer/gpu.py",  # requires GPU hardware not available in CI
 ]
 
 [tool.hatch]


### PR DESCRIPTION
Added `src/zarr/codecs/gpu.py` and `src/zarr/core/buffer/gpu.py` to the `omit` list in `pyproject.toml` — these files can't be covered in CI without GPU hardware, causing `codecov/project` to fail even though `codecov/patch` passes.

- Fixed typo in `docs/user-guide/gpu.rst`: `"Isseus"` → `"Issues"`